### PR TITLE
ENH: use c level distributions for random number generation in distributions module

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,23 +1,26 @@
 from distutils.core import Extension
+from os.path import join
 
 import numpy as np
 from Cython.Build import cythonize, build_ext
 
+
 extensions = [
     Extension(
-        "occuspytial/**", ["occuspytial/**.pyx"],
+        "occuspytial.distributions",
+        ["occuspytial/distributions.pyx"],
         include_dirs=[np.get_include()],
-        library_dirs=[np.get_include()],
+        library_dirs=[join(np.get_include(), '..', '..', 'random', 'lib')],
+        libraries=['npyrandom'],
+        define_macros=[('NPY_NO_DEPRECATED_API', 0)],
     ),
     Extension(
-        "occuspytial/gibbs/*", ["occuspytial/gibbs/*.pyx"],
+        "occuspytial/gibbs/*",
+        ["occuspytial/gibbs/*.pyx"],
         include_dirs=[np.get_include()],
         library_dirs=[np.get_include()],
     ),
 ]
-
-ext = cythonize(extensions, include_path=[np.get_include()])
-
 
 # source: https://github.com/sdispater/pendulum/blob/1.x/build.py
 def build(setup_kwargs):
@@ -25,6 +28,6 @@ def build(setup_kwargs):
     This function is mandatory in order to build the extensions.
     """
     setup_kwargs.update({
-        'ext_modules': ext,
+        'ext_modules': cythonize(extensions),
         'cmdclass': {'build_ext': build_ext}
     })

--- a/occuspytial/gibbs/logit.py
+++ b/occuspytial/gibbs/logit.py
@@ -30,9 +30,10 @@ class LogitICARGibbs(GibbsBase):
         else:
             self.fixed.pertub = pertub
 
-        self.dists.pg = PolyaGamma()
-        self.dists.sum2zero_mvnorm = SumToZeroMultivariateNormal()
-        self.dists.mvnorm = DenseMultivariateNormal2()
+        random_state = self.random_state
+        self.dists.pg = PolyaGamma(random_state)
+        self.dists.sum2zero_mvnorm = SumToZeroMultivariateNormal(random_state)
+        self.dists.mvnorm = DenseMultivariateNormal2(random_state)
 
     def _update_omega_a(self):
         not_obs_occupancy = [i for i in self.fixed.not_obs if self.state.z[i]]
@@ -49,7 +50,7 @@ class LogitICARGibbs(GibbsBase):
 
     def _update_tau(self):
         eta = self.state.eta
-        rate = (0.5 * eta @ self.fixed.Q @ eta) + self.fixed.tau_rate
+        rate = 0.5 * eta @ (self.fixed.Q * eta) + self.fixed.tau_rate
         self.state.tau = self.rng.gamma(self.fixed.tau_shape, 1 / rate)
 
     def _update_eta(self):

--- a/occuspytial/gibbs/probit.py
+++ b/occuspytial/gibbs/probit.py
@@ -22,7 +22,7 @@ class ProbitRSRGibbs(GibbsBase):
         self.state.omega_b = np.zeros(self.fixed.n)
         self.fixed.XTX_plus_bprec = self.X.T @ self.X + self.fixed.b_prec
         self.fixed.eps_chol_factor = np.ones(self.X.shape[0]) / np.sqrt(2)
-        self.dists.mvnorm = DenseMultivariateNormal2()
+        self.dists.mvnorm = DenseMultivariateNormal2(self.random_state)
 
         # XTX_i = inv(self.X.T @ self.X)
         chol = np.linalg.cholesky(self.X.T @ self.X)
@@ -104,7 +104,7 @@ class ProbitRSRGibbs(GibbsBase):
 
     def _update_tau(self):
         eta = self.state.eta
-        rate = (0.5 * eta @ self.fixed.Q @ eta) + self.fixed.tau_rate
+        rate = 0.5 * eta @ (self.fixed.Q * eta) + self.fixed.tau_rate
         self.state.tau = self.rng.gamma(self.fixed.tau_shape, 1 / rate)
 
     def _update_eps(self):


### PR DESCRIPTION
Since numpy 1.19 we can access the c-level functions for random number generation. We should use those instead of the higher level ones