### PR TITLE
MAINT: Use fast SFC64 bitgenator instead of the default one

### DIFF
--- a/occuspytial/gibbs/base.py
+++ b/occuspytial/gibbs/base.py
@@ -29,7 +29,7 @@ class GibbsBase(ABC):
         self.y = Data(y)
         self.chain = None
         self.random_state = random_state
-        self.rng = np.random.default_rng(random_state)
+        self.rng = np.random.default_rng(np.random.SFC64(random_state))
 
     @abstractmethod
     def step(self):
@@ -188,5 +188,6 @@ class GibbsBase(ABC):
         out = type(self).__new__(self.__class__)
         out.__dict__.update(self.__dict__)
         # make sure the copy has its own unique random number generator
-        out.__dict__['rng'] = np.random.default_rng()
+        bitgen = np.random.SFC64(self.rng.integers(low=0, high=2 ** 63))
+        out.__dict__['rng'] = np.random.default_rng(bitgen)
         return out

--- a/occuspytial/gibbs/logit.py
+++ b/occuspytial/gibbs/logit.py
@@ -50,7 +50,7 @@ class LogitICARGibbs(GibbsBase):
 
     def _update_tau(self):
         eta = self.state.eta
-        rate = 0.5 * eta @ (self.fixed.Q * eta) + self.fixed.tau_rate
+        rate = 0.5 * eta @ self.fixed.Q @ eta + self.fixed.tau_rate
         self.state.tau = self.rng.gamma(self.fixed.tau_shape, 1 / rate)
 
     def _update_eta(self):

--- a/occuspytial/gibbs/probit.py
+++ b/occuspytial/gibbs/probit.py
@@ -104,7 +104,7 @@ class ProbitRSRGibbs(GibbsBase):
 
     def _update_tau(self):
         eta = self.state.eta
-        rate = 0.5 * eta @ (self.fixed.Q * eta) + self.fixed.tau_rate
+        rate = 0.5 * eta @ self.fixed.Q @ eta + self.fixed.tau_rate
         self.state.tau = self.rng.gamma(self.fixed.tau_shape, 1 / rate)
 
     def _update_eps(self):

--- a/occuspytial/utils.py
+++ b/occuspytial/utils.py
@@ -35,7 +35,7 @@ def make_data(
     max_neighbors=8,
     random_state=None,
  ):
-    rng = np.random.default_rng(random_state)
+    rng = np.random.default_rng(np.random.SFC64(random_state))
 
     if n < 100:
         raise ValueError('n cant be lower than 50')


### PR DESCRIPTION
As shown here: https://numpy.org/devdocs/reference/random/performance.html

SFG64 is faster than PCG64 for this project's usecase.