### PR TITLE
ENH: use a faster bernouilli random sampling algorithm for gibbs samplers

### DIFF
--- a/occuspytial/gibbs/base.py
+++ b/occuspytial/gibbs/base.py
@@ -53,7 +53,9 @@ class GibbsBase(ABC):
         self.fixed.not_surveyed = [
             site for site in range(self.fixed.n) if site not in self.y.surveyed
         ]
+        self.fixed.n_ns = len(self.fixed.not_surveyed)
         self.fixed.not_obs = [i for i in self.y.surveyed if not self.state.z[i]]
+        self.fixed.n_no = len(self.fixed.not_obs)
         self.fixed.obs = [i for i in self.y.surveyed if self.state.z[i]]
         self.fixed.W_not_obs = self.W[self.fixed.not_obs]
         self.fixed.visits_not_obs = self.W.visits(self.fixed.not_obs)

--- a/occuspytial/gibbs/logit.py
+++ b/occuspytial/gibbs/logit.py
@@ -77,7 +77,9 @@ class LogitICARGibbs(GibbsBase):
 
     def _update_z(self):
         no = self.fixed.not_obs
+        n_no = self.fixed.n_no
         ns = self.fixed.not_surveyed
+        n_ns = self.fixed.n_ns
         beta = self.state.beta
         spat = self.state.spatial
 
@@ -89,12 +91,12 @@ class LogitICARGibbs(GibbsBase):
         x = y + self.state.section_sums
         c = -np.logaddexp(0, xb_eta)
         logp = x - np.logaddexp(c, x)
-        self.state.z[no] = self.rng.binomial(n=1, p=np.exp(logp))
+        self.state.z[no] = np.log(self.rng.uniform(size=n_no)) < logp
 
         if ns:
             xb_eta_ns = self.X[ns] @ beta + spat[ns]
             logp = -np.logaddexp(0, -xb_eta_ns)
-            self.state.z[ns] = self.rng.binomial(n=1, p=np.exp(logp))
+            self.state.z[ns] = np.log(self.rng.uniform(size=n_ns)) < logp
 
         self.state.k = self.state.z - 0.5
 

--- a/occuspytial/gibbs/probit.py
+++ b/occuspytial/gibbs/probit.py
@@ -136,7 +136,9 @@ class ProbitRSRGibbs(GibbsBase):
 
     def _update_z(self):
         no = self.fixed.not_obs
+        n_no = self.fixed.n_no
         ns = self.fixed.not_surveyed
+        n_ns = self.fixed.n_ns
         beta = self.state.beta
         K_eta = self.state.spatial
         xb_eta = self.X[no] @ beta + K_eta[no] + self.state.eps[no]
@@ -154,11 +156,11 @@ class ProbitRSRGibbs(GibbsBase):
         lognum = lognum1 + self.state.section_sums
         prod_sf = np.exp(self.state.section_sums)
         logp = lognum - np.log(1 - num1 + num1 * prod_sf)
-        self.state.z[no] = self.rng.binomial(n=1, p=np.exp(logp))
+        self.state.z[no] = np.log(self.rng.uniform(size=n_no)) < logp
 
         if ns:
             p = ndtr(self.X[ns] @ beta + K_eta[ns] + self.state.eps[ns])
-            self.state.z[ns] = self.rng.binomial(n=1, p=p)
+            self.state.z[ns] = self.rng.uniform(size=n_ns) < p
 
     def step(self):
         self._update_omega_b()


### PR DESCRIPTION
In the Gibbs samplers the probability of the binomial variable to sample from inside the `update_z` is usually in the log form. computing the exponential and then passing the result to the numpy random number generator is a little inefficient. This paper:
https://dl.acm.org/doi/10.1145/42372.42381 shows an algorithm to quickly sample from a bernouilli using just uniform random variables. This makes it possible to generate samples using the log-probability and avoid explicitly computing exp(logp). This saves time and results in a speed up of 2.3 times on my machine.