### PR TITLE
ENH: add a function to get an instance of a numpy generator

### DIFF
--- a/occuspytial/distributions.pyx
+++ b/occuspytial/distributions.pyx
@@ -27,6 +27,9 @@ except ImportError:
     )
     USE_SKSPARSE = False
 
+from .utils import get_generator
+
+
 __all__ = (
     'SumToZeroMultivariateNormal',
     'SparseMultivariateNormal',
@@ -113,7 +116,6 @@ cdef class DenseMultivariateNormal(Distribution):
                 std_v[i] += mean[i]
 
         return std, chol
-
 
 
 cdef class DenseMultivariateNormal2(Distribution):
@@ -270,7 +272,7 @@ cdef class PolyaGamma:
 
     def __cinit__(self, random_state=None):
         if random_state is None:
-            rng = np.random.default_rng(np.random.SFC64(random_state))
+            rng = get_generator(random_state)
             random_state = rng.integers(low=0, high=2 ** 63)
         self.rng = PyPolyaGamma(random_state)
         self.random_state = random_state

--- a/occuspytial/gibbs/base.py
+++ b/occuspytial/gibbs/base.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 from ..chain import Chain
 from ..data import Data
 from ..posterior import PosteriorParameter
+from ..utils import get_generator
 
 from .parallel import sample_parallel
 from .state import State, FixedState
@@ -29,7 +30,7 @@ class GibbsBase(ABC):
         self.y = Data(y)
         self.chain = None
         self.random_state = random_state
-        self.rng = np.random.default_rng(np.random.SFC64(random_state))
+        self.rng = get_generator(random_state)
 
     @abstractmethod
     def step(self):
@@ -190,6 +191,6 @@ class GibbsBase(ABC):
         out = type(self).__new__(self.__class__)
         out.__dict__.update(self.__dict__)
         # make sure the copy has its own unique random number generator
-        bitgen = np.random.SFC64(self.rng.integers(low=0, high=2 ** 63))
-        out.__dict__['rng'] = np.random.default_rng(bitgen)
+        random_state = self.rng.integers(low=0, high=2 ** 63)
+        out.__dict__['rng'] = get_generator(random_state)
         return out

--- a/occuspytial/utils.py
+++ b/occuspytial/utils.py
@@ -3,6 +3,11 @@ import warnings
 import numpy as np
 
 
+def get_generator(random_state):
+    bitgenerator = np.random.SFC64(random_state)
+    return np.random.default_rng(bitgenerator)
+
+
 def rand_precision_mat(lat_row, lat_col, max_neighbors=8, rho=1):
     if max_neighbors == 8:
         nn = 'queen'
@@ -35,7 +40,7 @@ def make_data(
     max_neighbors=8,
     random_state=None,
  ):
-    rng = np.random.default_rng(np.random.SFC64(random_state))
+    rng = get_generator(random_state)
 
     if n < 100:
         raise ValueError('n cant be lower than 50')


### PR DESCRIPTION
since #12 it makes sense to have a single function to be used to get instances of the numpy Generator class. This reduces duplicated code and is much cleaner than writing `np.random.default_rng(np.random.SFC64(random_state))` everytime.